### PR TITLE
Column Header Escaping

### DIFF
--- a/LumenWorks.Framework.Tests.Unit/LumenWorks.Framework.Tests.Unit.csproj
+++ b/LumenWorks.Framework.Tests.Unit/LumenWorks.Framework.Tests.Unit.csproj
@@ -46,8 +46,8 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.4.6.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="nunit.framework">
+      <HintPath>..\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/nDump.Unit/ColumnHeaderKeywordEscapingStrategyTest.cs
+++ b/nDump.Unit/ColumnHeaderKeywordEscapingStrategyTest.cs
@@ -55,5 +55,29 @@ namespace nDump.Unit
 
             Assert.AreEqual(new string[]{"other","[database]"}, escaped);
         }
+        [Test]
+        public void ShouldEscapeASpace()
+        {
+            var g = new ColumnHeaderKeywordEscapingStrategy();
+            var escaped = g.Escape("What happened");
+
+            Assert.AreEqual("[What happened]", escaped);
+        }
+        [Test]
+        public void ShouldEscapeQuestionMarks()
+        {
+            var g = new ColumnHeaderKeywordEscapingStrategy();
+            var escaped = g.Escape("When?");
+
+            Assert.AreEqual("[When?]", escaped);
+        }
+        [Test]
+        public void ShouldEscapeSlashes()
+        {
+            var g = new ColumnHeaderKeywordEscapingStrategy();
+            var escaped = g.Escape("Today/Tomorrow");
+
+            Assert.AreEqual("[Today/Tomorrow]", escaped);
+        }
     }
 }

--- a/nDump.sln
+++ b/nDump.sln
@@ -27,8 +27,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{FE26FDE2-574F-480E-96E6-4C2A5051D14A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FE26FDE2-574F-480E-96E6-4C2A5051D14A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FE26FDE2-574F-480E-96E6-4C2A5051D14A}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{FE26FDE2-574F-480E-96E6-4C2A5051D14A}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{FE26FDE2-574F-480E-96E6-4C2A5051D14A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{FE26FDE2-574F-480E-96E6-4C2A5051D14A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{FE26FDE2-574F-480E-96E6-4C2A5051D14A}.Debug|x86.ActiveCfg = Debug|x86
 		{FE26FDE2-574F-480E-96E6-4C2A5051D14A}.Debug|x86.Build.0 = Debug|x86
 		{FE26FDE2-574F-480E-96E6-4C2A5051D14A}.Release|Any CPU.ActiveCfg = Release|x86

--- a/nDump/ColumnHeaderKeywordEscapingStrategy.cs
+++ b/nDump/ColumnHeaderKeywordEscapingStrategy.cs
@@ -2,21 +2,21 @@
 
 namespace nDump
 {
-    public class ColumnHeaderKeywordEscapingStrategy: IEscapingStrategy
+    public class ColumnHeaderKeywordEscapingStrategy : IEscapingStrategy
     {
-        private string[] _keyWords= new[] {"user", "group", "database"};
+        private readonly string[] _keyWords = new[] {"user", "group", "database"};
+        private readonly string[] _nonsense = new[] {" ", "?", "/"};
 
         public string Escape(string value)
         {
-            return _keyWords.Contains(value.ToLower()) ? "[" + value + "]" : value;
+            var hasNonsense = _nonsense.Any(x => value.Contains(x));
+            var isKeyword = _keyWords.Contains(value.ToLower());
+            return (isKeyword || hasNonsense) ? "[" + value + "]" : value;
         }
 
         public string[] Escape(string[] values)
         {
-
             return values.Select(name => Escape(name)).ToArray();
         }
-
-        
     }
 }


### PR DESCRIPTION
- tests & functionality for escaping columns with a space, slash, or question mark
- updated LumenWorks reference to point to lib/nunit.framework.dll
- build configuration now builds nDump for `Any CPU`

pairing with [creade](http://github.com/creade)
