### PR TITLE
nDump - Now with extra cleaning power!

### DIFF
--- a/nDump.GUI/IgnoredColumnsForm.Designer.cs
+++ b/nDump.GUI/IgnoredColumnsForm.Designer.cs
@@ -9,7 +9,7 @@ namespace nDump.GUI
     public partial class IgnoredColumnsForm : Form
     {
         private Panel panel1;
-        private Button CancelButton;
+        private new Button CancelButton;
         private Button OkButton;
         private Label label1;
         private Panel panel2;

--- a/nDump.Integration/TestStringToStringGeneration.cs
+++ b/nDump.Integration/TestStringToStringGeneration.cs
@@ -47,7 +47,7 @@ namespace nDump.Integration
                                  sqlWriter, tableName, false));
             }
 
-            Assert.AreEqual("insert testTable (col1,col2) values\n('1','2')\n",sqlWriter.ToString());
+            Assert.AreEqual("insert testTable (col1,col2) values\n(N'1',N'2')\n",sqlWriter.ToString());
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace nDump.Integration
                 csvToSqlInsertConverter.Convert(new CsvTable(csvTextReader,
                                                              sqlWriter, tableName, false));
             }
-            Assert.AreEqual("insert testTable (col1,col2) values\n('1','2')\n,('3','4')\n",sqlWriter.ToString());
+            Assert.AreEqual("insert testTable (col1,col2) values\n(N'1',N'2')\n,(N'3',N'4')\n",sqlWriter.ToString());
         }
 
         public static int CountStringOccurrences(string text, string pattern)

--- a/nDump.Integration/TestStringToStringGeneration.cs
+++ b/nDump.Integration/TestStringToStringGeneration.cs
@@ -25,7 +25,7 @@ namespace nDump.Integration
             {
                 _stringBuilder.Append(sql);
             }
-            public string ToString()
+            public new string ToString()
             {
                 return _stringBuilder.ToString();
             }

--- a/nDump.Unit/ValueEscapingStrategyTest.cs
+++ b/nDump.Unit/ValueEscapingStrategyTest.cs
@@ -18,7 +18,7 @@ namespace nDump.Unit
         public void ShouldQuoteSingleValue()
         {
             string escape = _valueEscapingStrategy.Escape("test");
-            Assert.AreEqual("'test'",escape);
+            Assert.AreEqual("N'test'",escape);
         }
 
         [Test]
@@ -46,14 +46,14 @@ namespace nDump.Unit
         public void ShouldReplaceSingleQuoteWithDoubleSingleQuote()
         {
             string escape = _valueEscapingStrategy.Escape("a'b");
-            Assert.AreEqual("'a''b'", escape);
+            Assert.AreEqual("N'a''b'", escape);
         }
 
         [Test]
         public void ShouldEscapeMultipleValues()
         {
             string[] escape = _valueEscapingStrategy.Escape(new string[]{"a'b","b"});
-            Assert.AreEqual(new []{"'a''b'","'b'"}, escape);
+            Assert.AreEqual(new []{"N'a''b'","N'b'"}, escape);
         }
     }
 }

--- a/nDump/Configuration/nDumpOptions.cs
+++ b/nDump/Configuration/nDumpOptions.cs
@@ -11,8 +11,7 @@ namespace nDump.Configuration
         {
         }
 
-        public nDumpOptions(bool export, bool transform, bool import, string file, string csvDirectory, string sqlDirectory,
-                         string sourceConnectionString, string targetConnectionString, bool applyFilters, bool bulkInsert)
+        public nDumpOptions(bool export, bool transform, bool import, string file, string csvDirectory, string sqlDirectory, string sourceConnectionString, string targetConnectionString, bool applyFilters, bool bulkInsert)
         {
             Export = export;
             TargetConnectionString = targetConnectionString;
@@ -24,6 +23,7 @@ namespace nDump.Configuration
             File = file;
             CsvDirectory = csvDirectory;
             SqlDirectory = sqlDirectory;
+            Delimiter = ',';
         }
 
         public bool ApplyFilters { get; set; }
@@ -48,6 +48,8 @@ namespace nDump.Configuration
         public string SourceConnectionString { get; set; }
 
         public string TargetConnectionString { get; set; }
+
+        public char Delimiter { get; set; }
 
         public void Save(string fileName)
         {

--- a/nDump/Export/CsvGenerator.cs
+++ b/nDump/Export/CsvGenerator.cs
@@ -18,8 +18,7 @@ namespace nDump.Export
         private readonly IQueryExecutor _queryExecutor;
         private readonly string _destinationDirectory;
         private readonly string _bulkInsertDestinationDirectory;
-        private const char DelimiterChar = (char)0x09;  // Tab character as delimiter
-        private const string Delimiter = "\\t";
+        private const char Delimiter = '\t';
         private const string Off = "off";
         private const string On = "on";
         
@@ -67,7 +66,7 @@ namespace nDump.Export
                 results.Columns.Remove(column);
             }
 
-            var csvOptions = new CsvOptions(DontCare, ',', results.Columns.Count) {DateFormat = "g"};
+            var csvOptions = new CsvOptions(DontCare, Delimiter, results.Columns.Count) {DateFormat = "g"};
 
             var filename = _destinationDirectory + table.TableName.ToLower() + ".csv";
             try
@@ -192,7 +191,7 @@ namespace nDump.Export
 
         private string GenerateCsv(string tableName, DataTable results)
         {
-            var csvOptions = new CsvOptions(DontCare, DelimiterChar, results.Columns.Count)
+            var csvOptions = new CsvOptions(DontCare, Delimiter, results.Columns.Count)
             {
                 DateFormat = "g",
                 Encoding = Encoding.Unicode

--- a/nDump/Export/CsvGenerator.cs
+++ b/nDump/Export/CsvGenerator.cs
@@ -17,19 +17,15 @@ namespace nDump.Export
         private readonly ISelectionFilteringStrategy _selectionFilteringStrategy;
         private readonly IQueryExecutor _queryExecutor;
         private readonly string _destinationDirectory;
-        private readonly string _bulkInsertDestinationDirectory;
-        private const char Delimiter = '\t';
-        private const string Off = "off";
-        private const string On = "on";
-        
-        public CsvGenerator(ILogger logger, ISelectionFilteringStrategy selectionFilteringStrategy,
-                            IQueryExecutor queryExecutor, string destinationDirectory)
+        private readonly char _delimiter;
+
+        public CsvGenerator(ILogger logger, ISelectionFilteringStrategy selectionFilteringStrategy, IQueryExecutor queryExecutor, string destinationDirectory, char delimiter)
         {
             _logger = logger;
-            _destinationDirectory = destinationDirectory;
-            _bulkInsertDestinationDirectory = string.Format("{0}/bulkInsert", this._destinationDirectory);
+            _destinationDirectory = destinationDirectory;            
             _queryExecutor = queryExecutor;
             _selectionFilteringStrategy = selectionFilteringStrategy;
+            _delimiter = delimiter;
         }
 
         public void Generate(List<SqlTableSelect> selects)
@@ -57,22 +53,21 @@ namespace nDump.Export
 
         private void GenerateCsv(SqlTableSelect table)
         {
-            _logger.Log("     " + table.TableName);
+            _logger.Log("\t" + table.TableName);
             var select = _selectionFilteringStrategy.GetFilteredSelectStatement(table);
-            DataTable results =
+            var results =
                 _queryExecutor.ExecuteSelectStatement(select);
             foreach (var column in table.ExcludedColumns)
             {
                 results.Columns.Remove(column);
             }
 
-            var csvOptions = new CsvOptions(DontCare, Delimiter, results.Columns.Count) {DateFormat = "g"};
+            var csvOptions = new CsvOptions(DontCare, _delimiter, results.Columns.Count) {DateFormat = "g", Encoding = Encoding.UTF8};
 
             var filename = _destinationDirectory + table.TableName.ToLower() + ".csv";
             try
             {
-                CsvEngine.DataTableToCsv(results, filename, csvOptions);
-                GenerateBulkInsert(table, results, filename);
+                CsvEngine.DataTableToCsv(results, filename, csvOptions);                
             }
             catch (UnauthorizedAccessException ex)
             {
@@ -80,133 +75,6 @@ namespace nDump.Export
                     "nDump cannot access the CSV file at " + filename +
                     ". Is it checked out (TFS) or modifiable? This error may also occur if the file has been opened by another program.",
                     ex);
-            }
-        }
-
-        private void GenerateBulkInsert(SqlTableSelect selectedTable, DataTable results, string filename)
-        {
-            var castSelectQuery = new List<string>();
-            var selectQuery = new List<string>();
-            var selectQueryForView = new List<string>();
-
-            var tableName = selectedTable.TableName;
-
-            foreach (DataColumn dCol in results.Columns)
-            {
-                castSelectQuery.Add(dCol.DataType.Equals(typeof(Boolean))
-                                        ? string.Format("CAST ([{0}] AS bit) AS [{0}]", dCol.ColumnName)
-                                        : string.Format("[{0}]", dCol.ColumnName));
-                selectQueryForView.Add(dCol.DataType.Equals(typeof(Boolean))
-                                        ? string.Format("CAST ([{0}] AS varchar) AS [{0}]", dCol.ColumnName)
-                                        : string.Format("[{0}]", dCol.ColumnName));
-                selectQuery.Add(string.Format("[{0}]", dCol.ColumnName));
-            }
-
-            var castColumnQuery = string.Join(", ", castSelectQuery);
-            var columnQuery = string.Join(", ", selectQuery);
-            var columnQueryForView = string.Join(", ", selectQueryForView);
-            string cleanTableName = tableName.Replace(".", "_").Replace("[", "").Replace("]", "");
-
-            var sb = new StringBuilder();
-
-            CreateTempTable(sb, tableName, cleanTableName, columnQueryForView);
-
-            SetIdentityInsert(selectedTable, sb, On);
-
-            InsertToTable(tableName, sb, cleanTableName, columnQuery, castColumnQuery);
-
-            SetIdentityInsert(selectedTable, sb, Off);
-
-            DeleteTempTable(sb, cleanTableName);
-
-            var fileWriter = new FilePerStatementSqlFileWriter(_bulkInsertDestinationDirectory, tableName, _logger);
-            fileWriter.Write(sb.ToString());
-        }
-        private static void CreateTempTable(StringBuilder sb, string tableName, string cleanTableName, string columnQueryForView)
-        {
-
-            //            sb.AppendFormat(
-            //                @"IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[vw_{0}]') AND type in (N'V')) 
-            //                            BEGIN 
-            //                                DROP VIEW dbo.vw_{0} 
-            //                            END
-            //                       GO"
-            //                , cleanTableName).AppendLine();
-
-            //            sb.AppendFormat(
-            //                @"CREATE VIEW dbo.vw_{0}
-            //                  AS 
-            //                    SELECT {1}
-            //	                FROM {2}
-            //                  GO",
-            //                cleanTableName, columnQueryForView, tableName).AppendLine();
-
-            sb.AppendFormat(
-                @"IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[{0}_csv]') AND type in (N'U'))
-                  BEGIN
-	                DROP TABLE {0}_csv
-                  END
-                GO",
-                   cleanTableName).AppendLine();
-
-            sb.AppendFormat(
-                @"SELECT {0} INTO dbo.{1}_csv FROM {2} Where 1=2
-                  GO",
-                     columnQueryForView,
-                     cleanTableName,
-                     tableName
-                     ).AppendLine();
-        }
-        private static void InsertToTable(string tableName, StringBuilder sb, string cleanTableName, string columnQuery, string castColumnQuery)
-        {
-            sb.AppendFormat(
-                @"BULK INSERT dbo.{0}_csv
-	              FROM '$CSVPATH${1}.csv' 
-	              WITH
-	              (
-		            FIRSTROW = 2, 
-		            FIELDTERMINATOR = '{2}',
-		            ROWTERMINATOR = '\n',
-		            DATAFILETYPE ='widechar',
-                    KEEPIDENTITY 
-	              )
-                  GO", cleanTableName, tableName.ToLower(), Delimiter).AppendLine();
-
-            sb.AppendFormat(
-                @"INSERT into {0} ({1})
-                  SELECT {2} FROM dbo.{3}_csv
-                  GO", tableName, columnQuery, castColumnQuery, cleanTableName).AppendLine();
-        }
-
-        private static void DeleteTempTable(StringBuilder sb, string cleanTableName)
-        {
-            //            sb.AppendFormat(
-            //                @"DROP VIEW dbo.vw_{0} 
-            //                  GO", cleanTableName).AppendLine();
-
-            sb.AppendFormat(
-                @"DROP TABLE dbo.{0}_csv 
-                  GO", cleanTableName).AppendLine();
-        }
-
-        private string GenerateCsv(string tableName, DataTable results)
-        {
-            var csvOptions = new CsvOptions(DontCare, Delimiter, results.Columns.Count)
-            {
-                DateFormat = "g",
-                Encoding = Encoding.Unicode
-            };
-            var filename = _destinationDirectory + tableName.ToLower() + ".csv";
-            CsvEngine.DataTableToCsv(results, filename, csvOptions);
-            return filename;
-        }
-        private const string SetIdentityInsertFormatString = "set identity_insert {0} {1}";
-
-        private static void SetIdentityInsert(SqlTableSelect selectedTable, StringBuilder stringBuilder, String switcher)
-        {
-            if (selectedTable.HasIdentity)
-            {
-                stringBuilder.AppendFormat(SetIdentityInsertFormatString, selectedTable.TableName, switcher).AppendLine().AppendLine("GO ");
             }
         }
     }

--- a/nDump/Import/CsvDataImporter.cs
+++ b/nDump/Import/CsvDataImporter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
@@ -26,8 +27,29 @@ namespace nDump.Import
 
         public void RemoveDataAndImportFromSqlFiles(List<SqlTableSelect> dataSelects)
         {
+            ThrowExceptionIfInvalidDataPlan(dataSelects);
             DeleteDataFromAllDestinationTables(dataSelects);
             InsertDataIntoDestinationTables(dataSelects);
+        }
+
+        private void ThrowExceptionIfInvalidDataPlan(List<SqlTableSelect> tables)
+        {
+            var missingTables = new List<string>();
+            foreach (var table in tables)
+            {
+                var csvFile = Path.Combine(_csvDirectory, table.TableName + ".csv");
+                if (!File.Exists(csvFile))
+                    missingTables.Add(table.TableName);
+            }
+
+            if (missingTables.Count == 0) return;
+
+            var errorMessage =
+                string.Format(
+                    "The following tables have entries in the dataplan, but the corresponding CSVs are not present in {0}:\n{1}\n" +
+                    "Either remove the entries from the dataplan xml, or add the missing CSVs.\n",
+                    _csvDirectory, string.Join("\n", missingTables));
+            throw new Exception(errorMessage);
         }
 
         public void DeleteDataFromAllDestinationTables(List<SqlTableSelect> sqlTableSelects)

--- a/nDump/Import/SqlDataImporter.cs
+++ b/nDump/Import/SqlDataImporter.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Data.SqlClient;
+using System.IO;
 using System.Linq;
 using nDump.Logging;
 using nDump.Model;
@@ -64,15 +64,8 @@ namespace nDump.Import
 
         public void RemoveDataAndImportFromSqlFiles(List<SqlTableSelect> selects)
         {
-            try
-            {
-                DeleteDataFromAllDestinationTables(selects);
-                InsertDataIntoDesinationTables(selects);
-            }
-            catch (SqlException ex)
-            {
-                throw new nDumpApplicationException(ex.Message, ex);
-            }
+            DeleteDataFromAllDestinationTables(selects);
+            InsertDataIntoDesinationTables(selects);
         }
     }
 }

--- a/nDump/Import/SqlDataImporter.cs
+++ b/nDump/Import/SqlDataImporter.cs
@@ -29,7 +29,7 @@ namespace nDump.Import
             _logger.Log("Deleting table data from target in reverse order:");
             foreach (var table in tableSelects)
             {
-                _logger.Log("     " + table.TableName);
+                _logger.Log("\t" + table.TableName);
                 _queryExecutor.ExecuteNonQueryStatement("delete from " + table.TableName);
             }
         }
@@ -40,7 +40,7 @@ namespace nDump.Import
             foreach (var table in selects.ToList())
             {
                 if (table.DeleteOnly) continue;
-                _logger.Log("     " + table.TableName);
+                _logger.Log("\t" + table.TableName);
                 RunAllScriptFilesFor(table);
             }
         }

--- a/nDump/SqlServer/IQueryExecutor.cs
+++ b/nDump/SqlServer/IQueryExecutor.cs
@@ -6,5 +6,6 @@ namespace nDump.SqlServer
     {
         void ExecuteNonQueryStatement(string selectStatement);
         DataTable ExecuteSelectStatement(string selectStatement);
+        void ExecuteBulkInsert(string tableName, DataTable dataTable, bool keepIdentity);
     }
 }

--- a/nDump/SqlServer/QueryExecutor.cs
+++ b/nDump/SqlServer/QueryExecutor.cs
@@ -34,5 +34,23 @@ namespace nDump.SqlServer
                 return dsSelectResult;
             }
         }
+
+        public void ExecuteBulkInsert(string tableName, DataTable dataTable, bool keepIdentity)
+        {
+            var copyOptions = SqlBulkCopyOptions.TableLock;
+            copyOptions  |= keepIdentity ? SqlBulkCopyOptions.KeepIdentity : SqlBulkCopyOptions.Default;
+
+            using (var bulkCopy = new SqlBulkCopy(_connectionString, copyOptions))
+            {
+                bulkCopy.DestinationTableName = tableName;
+
+                foreach (DataColumn column in dataTable.Columns)
+                {
+                    bulkCopy.ColumnMappings.Add(column.ColumnName, column.ColumnName);
+                }
+               
+                bulkCopy.WriteToServer(dataTable);
+            }
+        }
     }
 }

--- a/nDump/Transformation/CsvTableFactory.cs
+++ b/nDump/Transformation/CsvTableFactory.cs
@@ -11,20 +11,22 @@ namespace nDump.Transformation
     {
         private readonly string _outputPath;
         private readonly IList<string> _tablesWithIdentities;
+        private readonly char _delimiter;
         private readonly ILogger _logger;
 
-        public CsvTableFactory(string outputPath, IList<string> tablesWithIdentities, ILogger logger)
+        public CsvTableFactory(string outputPath, IList<string> tablesWithIdentities, char delimiter, ILogger logger)
         {
             _outputPath = outputPath;
             _tablesWithIdentities = tablesWithIdentities;
+            _delimiter = delimiter;
             _logger = logger;
         }
 
         public ICsvTable CreateCsvTable(string file)
         {
             string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(file);
-            var filePerStatementSqlFileWriter = new FilePerStatementSqlFileWriter(_outputPath, fileNameWithoutExtension,_logger);
-            var reader = new CsvReader(File.OpenText(file), true, '\t', '\"', '\"', '#',
+            var filePerStatementSqlFileWriter = new FilePerStatementSqlFileWriter(_outputPath, fileNameWithoutExtension, _logger);
+            var reader = new CsvReader(File.OpenText(file), true, _delimiter, '\"', '\"', '#',
                                        ValueTrimmingOptions.UnquotedOnly);
             return new CsvTable(reader, filePerStatementSqlFileWriter, fileNameWithoutExtension,
                                 _tablesWithIdentities.Contains(fileNameWithoutExtension.ToLower()));

--- a/nDump/Transformation/DataTransformer.cs
+++ b/nDump/Transformation/DataTransformer.cs
@@ -9,21 +9,23 @@ namespace nDump.Transformation
     public class DataTransformer
     {
         private readonly ILogger _logger;
+        private readonly char _delimiter;
         private readonly string _sourceDirectory;
         private readonly string _sqlScriptDirectory;
         private readonly ICsvToSqlInsertConverter _csvToSqlInsertConverter;
 
-        public DataTransformer(string sqlScriptDirectory, string sourceDirectory, ILogger logger,
+        public DataTransformer(string sqlScriptDirectory, string sourceDirectory, ILogger logger, char delimiter,
                                ICsvToSqlInsertConverter csvToSqlInsertConverter)
         {
             _sqlScriptDirectory = sqlScriptDirectory;
             _sourceDirectory = sourceDirectory;
             _logger = logger;
+            _delimiter = delimiter;
             _csvToSqlInsertConverter = csvToSqlInsertConverter;
         }
 
-        public DataTransformer(string sqlScriptDirectory, string sourceDirectory, ILogger logger)
-            : this(sqlScriptDirectory, sourceDirectory, logger, new CsvToSqlInsertConverter(999))
+        public DataTransformer(string sqlScriptDirectory, string sourceDirectory, ILogger logger, char delimiter)
+            : this(sqlScriptDirectory, sourceDirectory, logger, delimiter, new CsvToSqlInsertConverter(999))
         {
         }
 
@@ -35,7 +37,7 @@ namespace nDump.Transformation
                     tableSelect => tableSelect.TableName.ToLower()).ToList();
             var files = Directory.GetFiles(_sourceDirectory);
 
-            var csvTableFactory = new CsvTableFactory(_sqlScriptDirectory, tablesWithIdentities,_logger);
+            var csvTableFactory = new CsvTableFactory(_sqlScriptDirectory, tablesWithIdentities,_delimiter, _logger);
             ICsvProcessor csvFileProcessor = new CsvFileProcessor(files, _csvToSqlInsertConverter, csvTableFactory);
 
             csvFileProcessor.Process();

--- a/nDump/Workflow/ConsoleExecutor.cs
+++ b/nDump/Workflow/ConsoleExecutor.cs
@@ -1,4 +1,5 @@
-﻿using nDump.Configuration;
+﻿using System;
+using nDump.Configuration;
 using nDump.Export;
 using nDump.Import;
 using nDump.Logging;
@@ -20,7 +21,7 @@ namespace nDump.Workflow
                 ImportIfSelected(nDumpOptions, logger, dataPlan);
                 BuklInsertIfSelected(nDumpOptions, logger, dataPlan);
             }
-            catch (nDumpApplicationException ex)
+            catch (Exception ex)
             {
                 logger.Log(ex);
                 return -1;
@@ -33,14 +34,16 @@ namespace nDump.Workflow
             if (!nDumpOptions.BulkInsert) return;
             try
             {
+
+
                 var importer = new CsvDataImporter(logger,
                                                    new QueryExecutor(nDumpOptions.TargetConnectionString),
                                                    nDumpOptions.CsvDirectory, nDumpOptions.Delimiter);
                 importer.RemoveDataAndImportFromSqlFiles(dataPlan.DataSelects);
             }
-            catch (nDumpApplicationException ex)
+            catch (Exception ex)
             {
-                throw new nDumpApplicationException("Import Of Sql Failed.",ex);
+                throw new nDumpApplicationException("Bulk Import Of Sql Failed.", ex);
             }
         }
 
@@ -54,11 +57,13 @@ namespace nDump.Workflow
                                                    new IncrementingNumberSqlScriptFileStrategy(nDumpOptions.SqlDirectory));
                 importer.RemoveDataAndImportFromSqlFiles(dataPlan.DataSelects);
             }
-            catch (nDumpApplicationException ex)
+            catch (Exception ex)
             {
                 throw new nDumpApplicationException("Import Of Sql Failed.",ex);
             }
         }
+
+      
 
         private void TransformIfSelected(nDumpOptions nDumpOptions, ILogger logger, DataPlan dataPlan)
         {
@@ -70,7 +75,7 @@ namespace nDump.Workflow
                                                       logger, nDumpOptions.Delimiter);
                 transformer.ConvertCsvToSql(dataPlan.DataSelects);
             }
-            catch (nDumpApplicationException ex)
+            catch (Exception ex)
             {
                 throw new nDumpApplicationException("Export To Csv Failed.", ex);
             }
@@ -93,7 +98,7 @@ namespace nDump.Workflow
                                                                     nDumpOptions.CsvDirectory, nDumpOptions.Delimiter));
                 exporter.ExportToCsv(dataPlan.SetupScripts, dataPlan.DataSelects);
             }
-            catch (nDumpApplicationException ex)
+            catch (Exception ex)
             {
                 throw new nDumpApplicationException("Export To Csv Failed.", ex);
             }

--- a/nDump/Workflow/ConsoleExecutor.cs
+++ b/nDump/Workflow/ConsoleExecutor.cs
@@ -18,6 +18,7 @@ namespace nDump.Workflow
                 ExportIfSelected(nDumpOptions, logger, dataPlan);
                 TransformIfSelected(nDumpOptions, logger, dataPlan);
                 ImportIfSelected(nDumpOptions, logger, dataPlan);
+                BuklInsertIfSelected(nDumpOptions, logger, dataPlan);
             }
             catch (nDumpApplicationException ex)
             {
@@ -25,6 +26,22 @@ namespace nDump.Workflow
                 return -1;
             }
             return 0;
+        }
+
+        private void BuklInsertIfSelected(nDumpOptions nDumpOptions, ILogger logger, DataPlan dataPlan)
+        {
+            if (!nDumpOptions.BulkInsert) return;
+            try
+            {
+                var importer = new CsvDataImporter(logger,
+                                                   new QueryExecutor(nDumpOptions.TargetConnectionString),
+                                                   nDumpOptions.CsvDirectory);
+                importer.RemoveDataAndImportFromSqlFiles(dataPlan.DataSelects);
+            }
+            catch (nDumpApplicationException ex)
+            {
+                throw new nDumpApplicationException("Import Of Sql Failed.",ex);
+            }
         }
 
         private void ImportIfSelected(nDumpOptions nDumpOptions, ILogger logger, DataPlan dataPlan)

--- a/nDump/Workflow/ConsoleExecutor.cs
+++ b/nDump/Workflow/ConsoleExecutor.cs
@@ -35,7 +35,7 @@ namespace nDump.Workflow
             {
                 var importer = new CsvDataImporter(logger,
                                                    new QueryExecutor(nDumpOptions.TargetConnectionString),
-                                                   nDumpOptions.CsvDirectory);
+                                                   nDumpOptions.CsvDirectory, nDumpOptions.Delimiter);
                 importer.RemoveDataAndImportFromSqlFiles(dataPlan.DataSelects);
             }
             catch (nDumpApplicationException ex)
@@ -67,7 +67,7 @@ namespace nDump.Workflow
             try
             {
                 var transformer = new DataTransformer(nDumpOptions.SqlDirectory, nDumpOptions.CsvDirectory,
-                                                      logger);
+                                                      logger, nDumpOptions.Delimiter);
                 transformer.ConvertCsvToSql(dataPlan.DataSelects);
             }
             catch (nDumpApplicationException ex)
@@ -90,7 +90,7 @@ namespace nDump.Workflow
 
                 var exporter = new SqlDataExporter(logger, filteringStrategy,
                                                    new CsvGenerator(logger, filteringStrategy, queryExecutor,
-                                                                    nDumpOptions.CsvDirectory));
+                                                                    nDumpOptions.CsvDirectory, nDumpOptions.Delimiter));
                 exporter.ExportToCsv(dataPlan.SetupScripts, dataPlan.DataSelects);
             }
             catch (nDumpApplicationException ex)

--- a/nDump/nDump.csproj
+++ b/nDump/nDump.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Export\CsvGenerator.cs" />
+    <Compile Include="Import\CsvDataImporter.cs" />
     <Compile Include="Transformation\Escaping\ColumnHeaderKeywordEscapingStrategy.cs" />
     <Compile Include="Workflow\ConsoleExecutor.cs" />
     <Compile Include="Logging\ConsoleLogger.cs" />

--- a/partcover.bat
+++ b/partcover.bat
@@ -1,2 +1,0 @@
-.\lib\PartCover\PartCover.exe --target .\lib\nunit-console-x86.exe --target-args /noshadow --include [nDump]*  --exclude [nDump]nDump.Configuration* --exclude [nDump]nDump.*Exception --exclude [nDump]nDump.Logging* --exclude [nDump]nDump.SqlServer* --exclude [nDump]nDump.Model* --target-work-dir .\nDump.Unit\bin\debug\ --target-args nDump.Unit.dll --output coverage.xml
-


### PR DESCRIPTION
Switched to using SqlBulkCopy for bulk inserts instead of BULK INSERT sql scripts.
The delimiter is now read from nDumpOptions. (Cannot be specified on the commandline yet)
Added check to ensure that the tables specified in the dataplan have corresponding CSVs present.
Fixed minor bug, failing tests, warnings. Cleaned up exception handling.
- Tanuj/Andrew
